### PR TITLE
Don’t repeat summary when rendering message

### DIFF
--- a/fedora_messaging_git_hook_messages/commit.py
+++ b/fedora_messaging_git_hook_messages/commit.py
@@ -57,9 +57,7 @@ COMMIT_SCHEMA = {
 STR_TEMPLATE = """From {hash} Mon Sep 17 00:00:00 2001
 From: {author_name} <{author_email}>
 Date: {date}
-Subject: {summary}
-
-{content}
+Subject: {content}
 ---
 
 {patch}

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -62,8 +62,6 @@ From: Dummy User <dummy@example.com>
 Date: 2023-11-30T10:42:31+01:00
 Subject: second commit
 
-second commit
-
 ---
 
 diff --git a/something.txt b/something.txt


### PR DESCRIPTION
It’s already contained in the content (or body) of the commit message.